### PR TITLE
Maybe can remove some useless code in `encodeBatch()`

### DIFF
--- a/producer/producer.go
+++ b/producer/producer.go
@@ -123,15 +123,8 @@ func (p *defaultProducer) encodeBatch(msgs ...*primitive.Message) *primitive.Mes
 	batch := new(primitive.Message)
 	batch.Topic = msgs[0].Topic
 	batch.Queue = msgs[0].Queue
-	if len(msgs) > 1 {
-		batch.Body = MarshalMessageBatch(msgs...)
-		batch.Batch = true
-	} else {
-		batch.Body = msgs[0].Body
-		batch.Flag = msgs[0].Flag
-		batch.WithProperties(msgs[0].GetProperties())
-		batch.TransactionId = msgs[0].TransactionId
-	}
+	batch.Body = MarshalMessageBatch(msgs...)
+	batch.Batch = true
 	return batch
 }
 


### PR DESCRIPTION
I streamlined the code of the encodeBatch() method and removed the else branch. The reasons are as follows:
The first line of encodeBatch() judges the case where len == 1. According to the judgment condition of if, else should take effect when len < 1 (ie len == 0). But the case of len == 0 is judged by checkMsg() before using the encodeBatch() method. Personally think that encodeBatch can be simplified.
Of course, the original author may need to keep the else branch from the perspective of code specifications or language features.

我精简了encodeBatch()方法的代码，删除了else分支。原因如下：
encodeBatch()第一行判断了 len == 1的情况。根据if的判断条件，else应该是len < 1时生效（即len == 0）。 但在使用encodeBatch()方法之前通过checkMsg()判断了len == 0的情况。 个人认为可以精简encodeBatch。
当然，原作者可能从代码规范或者语言特性方面考虑，需要保留else分支。